### PR TITLE
Convert fib route to typescript

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -4,7 +4,7 @@ import fibonacci from "./fib";
 import { Request, Response } from 'express';
 
 export default (req: Request, res: Response): void => {
-  const { num } = req.params;
+  const num:string = req.params.num;
 
   const fibN = fibonacci(parseInt(num));
   let result = `fibonacci(${num}) is ${fibN}`;

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import { Request, Response } from 'express';
 
-export default (req, res) => {
+export default (req: Request, res: Response): void => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
This PR merges the convert-fibRoute-to-typescript branch into main. Due to the need for improved type safety and adherence to our strict TypeScript ESLint configuration, I **added type annotations where TypeScript complained and also added explicit type for num.** That fixed the issues in _fibRoute.ts_ file. I tested the fix by using the **npm run lint command** and saw that no issues were reported for the _fibRoute.ts_ file. 